### PR TITLE
Python 3 compat

### DIFF
--- a/readthedocs_ext/readthedocs.py
+++ b/readthedocs_ext/readthedocs.py
@@ -41,9 +41,9 @@ class ReadtheDocsBuilder(StandaloneHTMLBuilder):
 
         # Pull project data from conf.py if it exists
         context = self.config.html_context
-        if context.has_key('current_version'):
+        if 'current_version' in context:
             self.version = context['current_version']
-        if context.has_key('slug'):
+        if 'slug' in context:
             self.project = context['slug']
 
         # Put in our media files instead of putting them in the docs.


### PR DESCRIPTION
dict.has_key was removed in Python 3 in favour of the "in" operator; hopefully this change will be sufficient to squash a build error I'm seeing with a project on RTD which is being built with Python 3:

```
Exception occurred:
  File "/home/docs/checkouts/readthedocs.org/user_builds/picamera/envs/latest/lib/python3.3/site-packages/readthedocs_ext/readthedocs.py", line 44, in init
    if context.has_key('current_version'):
AttributeError: 'dict' object has no attribute 'has_key'
The full traceback has been saved in /tmp/sphinx-err-ogwsym.log, if you want to report the issue to the developers.
Please also report this if it was a user error, so that a better error message can be provided next time.
Either send bugs to the mailing list at <http://groups.google.com/group/sphinx-dev/>,
or report them in the tracker at <http://bitbucket.org/birkenfeld/sphinx/issues/>. Thanks!
```
