### PR TITLE
Exclude extra header from offline builders

### DIFF
--- a/readthedocs_ext/readthedocs.py
+++ b/readthedocs_ext/readthedocs.py
@@ -102,7 +102,10 @@ def update_body(app, pagename, templatename, context, doctree):
     # This is monkey patched on the signal because we can't know what the user
     # has done with their `app.builder.templates` before now.
 
-    if not hasattr(app.builder.templates.render, '_patched'):
+    if (
+        app.builder.name in online_builders and not
+        hasattr(app.builder.templates.render, '_patched')
+    ):
         # Janky monkey patch of template rendering to add our content
         old_render = app.builder.templates.render
 


### PR DESCRIPTION
Related to https://github.com/rtfd/readthedocs.org/issues/2637

We don't need to insert the extra header for offline docs.

I tested it locally, it works as expected. We are going to still see this footer

![Screenshot_2019-03-27 Test Builds documentation](https://user-images.githubusercontent.com/4975310/55118595-d474aa00-50bc-11e9-9cb5-b1a74b7cb09a.png)

But all the links are dummy, and it's because we set the `READTHEDOCS` env variable, and we use that on the theme to put some dummy data before it gets replaced by the api response https://github.com/rtfd/sphinx_rtd_theme/blob/ddfdd35e6977f21fb1771734732756b0cf1d6bba/sphinx_rtd_theme/versions.html#L1
