### PR TITLE
External version warning banner

### DIFF
--- a/readthedocs_ext/external_version_warning.py
+++ b/readthedocs_ext/external_version_warning.py
@@ -16,7 +16,7 @@ except ImportError:
 log = getLogger(__name__)
 
 
-def process_external_version_warning_banner(app, doctree):
+def process_external_version_warning_banner(app, doctree, fromdocname):
     for document in doctree.traverse(nodes.document):
         text = 'This is an External Version created from pull/merge request.'
         prose = nodes.paragraph(text, text)

--- a/readthedocs_ext/external_version_warning.py
+++ b/readthedocs_ext/external_version_warning.py
@@ -1,0 +1,28 @@
+"""
+Add the ability to warning banner for external versions in every page.
+
+If the version type is external this will show a warning banner
+at the top of each page of the documentation.
+"""
+
+from docutils import nodes
+
+try:
+    # Avaliable from Sphinx 1.6
+    from sphinx.util.logging import getLogger
+except ImportError:
+    from logging import getLogger
+
+log = getLogger(__name__)
+
+
+def process_meta(app, doctree):
+    for document in doctree.traverse(nodes.document):
+        text = 'This is an External Version created from pull/merge request.'
+        prose = nodes.paragraph(text, text)
+        warning = nodes.warning(prose, prose)
+        document.insert(0, warning)
+
+
+def setup(app):
+    app.connect('doctree-resolved', process_meta)

--- a/readthedocs_ext/external_version_warning.py
+++ b/readthedocs_ext/external_version_warning.py
@@ -16,7 +16,7 @@ except ImportError:
 log = getLogger(__name__)
 
 
-def process_meta(app, doctree):
+def process_external_version_warning_banner(app, doctree):
     for document in doctree.traverse(nodes.document):
         text = 'This is an External Version created from pull/merge request.'
         prose = nodes.paragraph(text, text)
@@ -25,4 +25,4 @@ def process_meta(app, doctree):
 
 
 def setup(app):
-    app.connect('doctree-resolved', process_meta)
+    app.connect('doctree-resolved', process_external_version_warning_banner)

--- a/readthedocs_ext/external_version_warning.py
+++ b/readthedocs_ext/external_version_warning.py
@@ -1,10 +1,3 @@
-"""
-Add the ability to warning banner for external versions in every page.
-
-If the version type is external this will show a warning banner
-at the top of each page of the documentation.
-"""
-
 from docutils import nodes
 
 try:
@@ -18,7 +11,7 @@ log = getLogger(__name__)
 
 def process_external_version_warning_banner(app, doctree, fromdocname):
     """
-    Add the ability to warning banner for external versions in every page.
+    Add warning banner for external versions in every page.
 
     If the version type is external this will show a warning banner
     at the top of each page of the documentation.

--- a/readthedocs_ext/external_version_warning.py
+++ b/readthedocs_ext/external_version_warning.py
@@ -17,8 +17,14 @@ log = getLogger(__name__)
 
 
 def process_external_version_warning_banner(app, doctree, fromdocname):
+    """
+    Add the ability to warning banner for external versions in every page.
+
+    If the version type is external this will show a warning banner
+    at the top of each page of the documentation.
+    """
     for document in doctree.traverse(nodes.document):
-        text = 'This is an External Version created from pull/merge request.'
+        text = 'This Documentation was created from pull/merge request.'
         prose = nodes.paragraph(text, text)
         warning = nodes.warning(prose, prose)
         document.insert(0, warning)


### PR DESCRIPTION
This will add a warning banner to external version docs.

To use this we need to add this in the requirements as its not merged
`git+https://github.com/saadmk11/readthedocs-sphinx-ext/@external-version-warning`

![Screenshot from 2019-07-10 22-54-01](https://user-images.githubusercontent.com/24854406/60988546-a2ced880-a365-11e9-85a3-202e4e3da620.png)
