### PR TITLE
Dump sphinx domains docstrings

### DIFF
--- a/readthedocs_ext/readthedocs.py
+++ b/readthedocs_ext/readthedocs.py
@@ -213,14 +213,8 @@ def dump_sphinx_domains_data(app, pagename, templatename, context, doctree):
 
     The final output is in the following form::
         {
-            sphinx-domain-id-1: {
-                content: sphinx domain docstrings 1
-                pagename: page-name-1
-            },
-            sphinx-domain-id-2: {
-                content: sphinx domain docstrings 2
-                pagename: page-name-2
-            }
+            sphinx-domain-id-1: "docstrings for sphinx-domain-id-1"
+            sphinx-domain-id-2: "docstrings for sphinx-domain-id-2"
         }
     """
 

--- a/readthedocs_ext/readthedocs.py
+++ b/readthedocs_ext/readthedocs.py
@@ -242,27 +242,26 @@ def dump_sphinx_domains_data(app, pagename, templatename, context, doctree):
         desc_nodes = (node for node in doctree.traverse() if isinstance(node, addnodes.desc))
 
         for node in desc_nodes:
-            node_data = {}
+            temp_node_data = {}
             for child in node.traverse():
 
                 if isinstance(child, addnodes.desc_signature):
-                    node_data['ids'] = child.get('ids')
+                    temp_node_data['ids'] = child.get('ids')
 
                 elif isinstance(child, addnodes.desc_content):
                     content = child.astext().split('\n')
                     content = ' '.join((text.strip() for text in content if text))
-                    existing_content = node_data.setdefault('content', '')
+                    existing_content = temp_node_data.setdefault('content', '')
 
                     if existing_content:
-                        node_data['content'] = existing_content + ' ' + content
+                        temp_node_data['content'] = existing_content + ' ' + content
                     else:
-                        node_data['content'] = content
+                        temp_node_data['content'] = content
 
-            ids = node_data.pop('ids', None)
+            ids = temp_node_data.get('ids', None)
             if ids:
                 id_ = ids[0]  # ``ids`` is in the form of list
-                data[id_] = node_data
-                data[id_]['pagename'] = pagename
+                data[id_] = temp_node_data['content']
 
         if data:
             with open(outjson, 'w') as json_file:


### PR DESCRIPTION
This is working correctly on local.
Tested on projects:
- docs
- kuma (no file was generated because there were no sphinx domain objects except std:label and std:doc)
- sphinx docs
- notfound
- requests docs

In this json file, we will be having `id` and `content` of the sphinx domains.
We can then load the file in our tasks.py and get the content of the sphinx domains from its `anchor` property (which comes from objects.inv fle).

Ref docs: https://www.sphinx-doc.org/en/master/extdev/nodes.html#nodes-for-domain-specific-object-descriptions

Related PR: https://github.com/readthedocs/readthedocs.org/pull/5979