### PR TITLE
Make JS async where possible

### DIFF
--- a/readthedocs_ext/_templates/readthedocs-insert.html.tmpl
+++ b/readthedocs_ext/_templates/readthedocs-insert.html.tmpl
@@ -28,6 +28,6 @@ READTHEDOCS_DATA['source_suffix'] = {{ page_source_suffix|tojson }}
 {%- endif %}
 </script>
 
-<script type="text/javascript" src="{{ rtd_analytics_url }}"></script>
+<script type="text/javascript" src="{{ rtd_analytics_url }}" async="async"></script>
 
 <!-- end RTD <extrahead> -->

--- a/readthedocs_ext/readthedocs.py
+++ b/readthedocs_ext/readthedocs.py
@@ -65,7 +65,8 @@ def finalize_media(app):
     if sphinx.version_info < (1, 8):
         app.builder.script_files.append(js_file)
     else:
-        app.add_js_file(js_file)
+        kwargs = {'async': 'async'}     # Workaround reserved word in Py3.7
+        app.add_js_file(js_file, **kwargs)
 
 
 def update_body(app, pagename, templatename, context, doctree):


### PR DESCRIPTION
This will make analytics and footer JS load asynchronously. It is possible we see slightly reduced analytics from this but I doubt it will be significant. `readthedocs-doc-embed.js` already waits for `document.ready` before doing anything so I don't think there will be a significant effect there.

Because this is only available in the newer Sphinx API [`app.add_js_file`](http://www.sphinx-doc.org/en/master/extdev/appapi.html#sphinx.application.Sphinx.add_js_file), it will only apply if built with Sphinx 1.8+.

## Resources

* [MDN article on async](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#attr-async)
* [Browser support for async](https://caniuse.com/#feat=script-async) (IE10+ and modern browsers)