### PR TITLE
Add more versions to test against

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ python:
   - 2.7
   - 3.5
   - 3.6
+  - 3.8
 matrix:
   include:
     - python: 2.7

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     py{27,35,36}-sphinx{15,16,17,18}
-    py{35,36,37}-sphinx{21}
+    py{35,36,37,38}-sphinx{21,22,23,24,30}
     lint
 
 [testenv]
@@ -15,7 +15,11 @@ deps =
     sphinx16: Sphinx<1.7
     sphinx17: Sphinx<1.8
     sphinx18: Sphinx<1.9
-    sphinx21: Sphinx==2.1.0
+    sphinx21: Sphinx~=2.1.0
+    sphinx22: Sphinx~=2.2.0
+    sphinx23: Sphinx~=2.3.0
+    sphinx24: Sphinx~=2.4.0
+    sphinx30: Sphinx~=3.0.0
 commands =
     py.test {posargs}
 


### PR DESCRIPTION
This extension is installed by default in all the builds that happen on Read the Docs. The more versions we test against, the better.