### PR TITLE
Use Py3 for Lint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ python:
   - 3.8
 matrix:
   include:
-    - python: 2.7
+    - python: 3.7
       script: tox -e lint
     - python: 3.7
       dist: xenial

--- a/readthedocs_ext/mixins.py
+++ b/readthedocs_ext/mixins.py
@@ -18,7 +18,7 @@ except ImportError:
 log = getLogger(__name__)
 
 
-class BuilderMixin(object):  # pylint: disable=old-style-class
+class BuilderMixin(object):  # pylint: disable=useless-object-inheritance
 
     """Builder mixin class for copying and templating extra static files
 

--- a/tox.ini
+++ b/tox.ini
@@ -24,12 +24,13 @@ commands =
     py.test {posargs}
 
 [testenv:lint]
+# Requires Python3
 # Prospector >= 1.0 does not run under Python2 due to a bug
 # https://github.com/PyCQA/prospector/issues/274
 deps =
     .
-    sphinx
-    prospector<1.0
+    sphinx<3
+    prospector>1.0,<1.2
 commands =
     prospector \
     --profile-path={toxinidir} \


### PR DESCRIPTION
Run our Travis lint tests through Python 3.