### PR TITLE
Canonical URL: don't set it if is empty

### DIFF
--- a/readthedocs_ext/_templates/readthedocs-insert.html.tmpl
+++ b/readthedocs_ext/_templates/readthedocs-insert.html.tmpl
@@ -1,20 +1,22 @@
 
 <!-- RTD Extra Head -->
 
-{%- if pagename == "index" %}
-    {%- set canonical_page = "" %}
-{%- elif pagename.endswith("/index") %}
-    {%- set canonical_page = pagename[:-("/index"|length)] + "/" %}
-{%- else %}
-    {%- set ending = "/" if builder == "readthedocsdirhtml" else ".html" %}
-    {%- set canonical_page = pagename + ending %}
-{%- endif %}
+{%- if canonical_url %}
+    {%- if pagename == "index" %}
+        {%- set canonical_page = "" %}
+    {%- elif pagename.endswith("/index") %}
+        {%- set canonical_page = pagename[:-("/index"|length)] + "/" %}
+    {%- else %}
+        {%- set ending = "/" if builder == "readthedocsdirhtml" else ".html" %}
+        {%- set canonical_page = pagename + ending %}
+    {%- endif %}
 
-<!-- 
-Always link to the latest version, as canonical.
-http://docs.readthedocs.org/en/latest/canonical.html
--->
-<link rel="canonical" href="{{ canonical_url }}{{ canonical_page }}" />
+    <!-- 
+    Always link to the latest version, as canonical.
+    http://docs.readthedocs.org/en/latest/canonical.html
+    -->
+    <link rel="canonical" href="{{ canonical_url|e }}{{ canonical_page }}" />
+{%- endif %}
 
 <link rel="stylesheet" href="{{ rtd_css_url }}" type="text/css" />
 

--- a/tests/pyexample-json/conf.py
+++ b/tests/pyexample-json/conf.py
@@ -22,3 +22,4 @@ todo_include_todos = False
 html_theme = 'alabaster'
 html_static_path = ['_static']
 htmlhelp_basename = 'pyexampledoc'
+html_baseurl = 'https://example.com/'

--- a/tests/pyexample/conf.py
+++ b/tests/pyexample/conf.py
@@ -29,4 +29,5 @@ html_context = {
     'user_analytics_code': '',
     'global_analytics_code': "malic''ious",
     'commit': 'deadd00d',
+    'canonical_url': 'https://example.com/"',
 }


### PR DESCRIPTION
Fix https://github.com/readthedocs/readthedocs-sphinx-ext/issues/82

Ref https://github.com/readthedocs/readthedocs-sphinx-ext/issues/83

We need to release the extension first, make sure all builds are using
that version and then release https://github.com/readthedocs/readthedocs.org/pull/7540