### PR TITLE
Update canonical_url to properly respect builder

### DIFF
--- a/readthedocs_ext/_templates/readthedocs-insert.html.tmpl
+++ b/readthedocs_ext/_templates/readthedocs-insert.html.tmpl
@@ -7,11 +7,11 @@
     {%- elif pagename.endswith("/index") %}
         {%- set canonical_page = pagename[:-("/index"|length)] + "/" %}
     {%- else %}
-        {%- set ending = "/" if builder == "readthedocsdirhtml" else ".html" %}
+        {%- set ending = "/" if 'dirhtml' in builder else ".html" %}
         {%- set canonical_page = pagename + ending %}
     {%- endif %}
 
-    <!-- 
+    <!--
     Always link to the latest version, as canonical.
     http://docs.readthedocs.org/en/latest/canonical.html
     -->


### PR DESCRIPTION
We have this behind a default_true feature flag,
so this is likely currently broken for all dirhtml builds.