### PR TITLE
Tox installs the package by default, there's no need to specify directory

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -2,16 +2,14 @@
 envlist =
     py{27,36}-sphinx{15,16,17,18}
     py{36,37,38,39}-sphinx{21,22,23,24,30,31,32,33,34,35,40,41,42,43,44,latest}
-    py310-sphinx-{42,43,44,latest}
+    py310-sphinx{42,43,44,latest}
     lint
 
 [testenv]
 setenv =
     LANG=C
 deps =
-    .
     pytest
-    mock
     sphinx15: Sphinx<1.6
     sphinx16: Sphinx<1.7
     sphinx17: Sphinx<1.8
@@ -38,7 +36,6 @@ commands =
 
 [testenv:lint]
 deps =
-    .
     sphinx<3
     prospector==1.3.1
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,7 @@ setenv =
     LANG=C
 deps =
     pytest
+    jinja2<3.1
     sphinx15: Sphinx<1.6
     sphinx16: Sphinx<1.7
     sphinx17: Sphinx<1.8
@@ -32,11 +33,11 @@ deps =
     sphinxlatest: Sphinx
     sphinxmaster: git+https://github.com/sphinx-doc/sphinx.git@master
 commands =
-    py.test {posargs}
+    pytest {posargs}
 
 [testenv:lint]
 deps =
-    sphinx<3
+    sphinx<5
     prospector==1.3.1
 commands =
     prospector \


### PR DESCRIPTION
Why change? I package this library to Fedora where we have automation to parse `tox.ini` files and run upstream tests during the package RPM build. Our automation can't parse the dot, but it shouldn't even have to - tox [installs the package](https://tox.wiki/en/latest/index.html?highlight=installs#current-features) by default. I've checked tox behaves the same way with and without the dot.