### PR TITLE
External version warning: avoid using the deprecated traverse method

### DIFF
--- a/readthedocs_ext/external_version_warning.py
+++ b/readthedocs_ext/external_version_warning.py
@@ -48,9 +48,7 @@ def process_external_version_warning_banner(app, doctree, fromdocname):
     ]
     prose = nodes.paragraph('', '', *children)
     warning_node = nodes.warning(prose, prose)
-
-    for document in doctree.traverse(nodes.document):
-        document.insert(0, warning_node)
+    doctree.insert(0, warning_node)
 
 
 def setup(app):


### PR DESCRIPTION
Node.traverse is deprecated in favor of Node.findall,
but we actually don't need this operation at all.

The doctree node is the top level document node we are
searching for, so there is no need to find it.