### PR TITLE
Remove distutils

### DIFF
--- a/readthedocs_ext/readthedocs.py
+++ b/readthedocs_ext/readthedocs.py
@@ -8,7 +8,7 @@ import os
 import re
 import types
 from datetime import datetime
-from distutils.version import LooseVersion
+from packaging.version import Version
 
 import sphinx
 from sphinx import package_dir
@@ -101,7 +101,7 @@ def update_body(app, pagename, templatename, context, doctree):
     if theme_css.endswith('sphinx_rtd_theme.css'):
         try:
             import sphinx_rtd_theme  # noqa
-            inject_css = LooseVersion(sphinx_rtd_theme.__version__) < LooseVersion('0.4.0')
+            inject_css = Version(sphinx_rtd_theme.__version__) < Version('0.4.0')
         except ImportError:
             pass
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     url='http://github.com/readthedocs/readthedocs-sphinx-ext',
     license='MIT',
     description='Sphinx extension for Read the Docs overrides',
-    install_requires=['requests', 'Jinja2>=2.9'],
+    install_requires=['requests', 'Jinja2>=2.9', 'packaging'],
     package_dir={'': '.'},
     packages=find_packages('.', exclude=['tests']),
     long_description=codecs.open("README.rst", "r", "utf-8").read(),


### PR DESCRIPTION
Removes direct call to `distutils` in favor of more modern `packaging` library.

I'm pretty sure this matches the design decision made in #106.  Happy to change if not.

Fixes #106 