### PR TITLE
Telemetry: dump `app.extensions` and `app.config.html_theme`

### DIFF
--- a/readthedocs_ext/readthedocs.py
+++ b/readthedocs_ext/readthedocs.py
@@ -421,6 +421,7 @@ def setup(app):
     app.connect('build-finished', dump_sphinx_data)
 
     if sphinx.version_info >= (1, 8, 0):
+        # `config-inited` event was introduced in Sphinx 1.8
         app.connect('config-inited', dump_telemetry)
 
     # Embed

--- a/readthedocs_ext/readthedocs.py
+++ b/readthedocs_ext/readthedocs.py
@@ -346,8 +346,8 @@ def dump_telemetry(app, config):
     )
     outjson = os.path.join(build_json, 'telemetry.json')
     outdir = os.path.dirname(outjson)
-    try:
 
+    try:
         if not os.path.exists(outdir):
             os.makedirs(outdir)
 

--- a/readthedocs_ext/readthedocs.py
+++ b/readthedocs_ext/readthedocs.py
@@ -353,8 +353,7 @@ def dump_telemetry(app, config):
 
         with open(outjson, 'w+') as json_file:
             data = {
-                # https://github.com/sphinx-doc/sphinx/blob/5.x/sphinx/application.py#L139
-                'extensions': [name for name, _ in app.extensions.items()],
+                'extensions': app.config.extensions,
                 'html_theme': app.config.html_theme,
             }
             json.dump(data, json_file, indent=4)

--- a/readthedocs_ext/readthedocs.py
+++ b/readthedocs_ext/readthedocs.py
@@ -346,15 +346,20 @@ def dump_telemetry(app, config):
     )
     outjson = os.path.join(build_json, 'telemetry.json')
     outdir = os.path.dirname(outjson)
-    if not os.path.exists(outdir):
-        os.makedirs(outdir)
-    with open(outjson, 'w+') as json_file:
-        data = {
-            # https://github.com/sphinx-doc/sphinx/blob/5.x/sphinx/application.py#L139
-            'extensions': [name for name, _ in app.extensions.items()],
-            'html_theme': app.config.html_theme,
-        }
-        json.dump(data, json_file, indent=4)
+    try:
+
+        if not os.path.exists(outdir):
+            os.makedirs(outdir)
+
+        with open(outjson, 'w+') as json_file:
+            data = {
+                # https://github.com/sphinx-doc/sphinx/blob/5.x/sphinx/application.py#L139
+                'extensions': [name for name, _ in app.extensions.items()],
+                'html_theme': app.config.html_theme,
+            }
+            json.dump(data, json_file, indent=4)
+    except Exception:
+        log.exception("Something went wrong when dumping Telemetry data.")
 
 
 class ReadtheDocsBuilder(StandaloneHTMLBuilder):

--- a/readthedocs_ext/readthedocs.py
+++ b/readthedocs_ext/readthedocs.py
@@ -338,6 +338,25 @@ def dump_sphinx_data(app, exception):
         )
 
 
+def dump_telemetry(app, config):
+    # We need to get the output directory where the docs are built
+    # _build/json.
+    build_json = os.path.abspath(
+        os.path.join(app.outdir, '..', 'json')
+    )
+    outjson = os.path.join(build_json, 'telemetry.json')
+    outdir = os.path.dirname(outjson)
+    if not os.path.exists(outdir):
+        os.makedirs(outdir)
+    with open(outjson, 'w+') as json_file:
+        data = {
+            # https://github.com/sphinx-doc/sphinx/blob/5.x/sphinx/application.py#L139
+            'extensions': [name for name, _ in app.extensions.items()],
+            'html_theme': app.config.html_theme,
+        }
+        json.dump(data, json_file, indent=4)
+
+
 class ReadtheDocsBuilder(StandaloneHTMLBuilder):
 
     """
@@ -395,6 +414,9 @@ def setup(app):
     app.connect('html-page-context', generate_json_artifacts)
     app.connect('build-finished', remove_search_init)
     app.connect('build-finished', dump_sphinx_data)
+
+    if sphinx.version_info >= (1, 8, 0):
+        app.connect('config-inited', dump_telemetry)
 
     # Embed
     app.add_directive('readthedocs-embed', EmbedDirective)


### PR DESCRIPTION
Dump data from Sphinx into a JSON file that will be read and processed by our Telemetry collector. This will help us to get some insights about extensions and theme usage.

Related to: https://github.com/readthedocs/readthedocs.org/pull/9639