### PR TITLE
Remove build-time field to avoid changing all pages on each build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,8 +11,8 @@ commands:
         default: "21,22,23,24,30,31,32,33,34,35,40,41,42,43,44,latest"
     steps:
       - checkout
-      - run: pip install --user tox
-      - run: tox -e "<<parameters.version>>-sphinx{<<parameters.sphinx-version>>}"
+      - run: pip install --user 'tox<5'
+      - run: tox run -e "<<parameters.version>>-sphinx{<<parameters.sphinx-version>>}"
 
 jobs:
   py27:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,8 +11,10 @@ commands:
         default: "21,22,23,24,30,31,32,33,34,35,40,41,42,43,44,latest"
     steps:
       - checkout
-      - run: pip install --user 'tox<5'
-      - run: tox run -e "<<parameters.version>>-sphinx{<<parameters.sphinx-version>>}"
+      # NOTE: update tox to tox<5 when https://github.com/tox-dev/tox/issues/2850
+      # is fixed.
+      - run: pip install --user 'tox<4'
+      - run: tox -e "<<parameters.version>>-sphinx{<<parameters.sphinx-version>>}"
 
 jobs:
   py27:

--- a/readthedocs_ext/readthedocs.py
+++ b/readthedocs_ext/readthedocs.py
@@ -155,7 +155,6 @@ def update_body(app, pagename, templatename, context, doctree):
                 'source_suffix': ctx.get('source_suffix', ''),
                 'page': ctx.get('pagename', ''),
                 'api_host': ctx.get('api_host', ''),
-                'commit': ctx.get('commit', ''),
                 'ad_free': ctx.get('ad_free', ''),
                 'global_analytics_code': ctx.get('global_analytics_code'),
                 'user_analytics_code': ctx.get('user_analytics_code'),

--- a/readthedocs_ext/readthedocs.py
+++ b/readthedocs_ext/readthedocs.py
@@ -7,11 +7,9 @@ import json
 import os
 import re
 import types
-from datetime import datetime
 from packaging.version import Version
 
 import sphinx
-from sphinx import package_dir
 from sphinx.util.console import bold
 
 
@@ -159,7 +157,6 @@ def update_body(app, pagename, templatename, context, doctree):
                 'api_host': ctx.get('api_host', ''),
                 'commit': ctx.get('commit', ''),
                 'ad_free': ctx.get('ad_free', ''),
-                'build_date': datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ'),
                 'global_analytics_code': ctx.get('global_analytics_code'),
                 'user_analytics_code': ctx.get('user_analytics_code'),
                 'subprojects': dict(ctx.get('subprojects', [])),


### PR DESCRIPTION
We are re-uploading all pages even if they didn't change anything because on each build we inject a different date-time.
As far as I can see, we aren't using this field anywhere in our code base.