### PR TITLE
Stop generating JSON data

### DIFF
--- a/readthedocs_ext/readthedocs.py
+++ b/readthedocs_ext/readthedocs.py
@@ -49,26 +49,6 @@ ONLINE_BUILDERS = [
     'readthedocsdirhtml',
     'readthedocssinglehtml',
 ]
-# Only run JSON output once during HTML build
-# This saves resources and keeps filepaths correct,
-# because singlehtml filepaths are different
-JSON_BUILDERS = [
-    'html',
-    'dirhtml',
-    'readthedocs',
-    'readthedocsdirhtml',
-]
-
-# Whitelist keys that we want to output
-# to the json artifacts.
-JSON_KEYS = [
-    'body',
-    'title',
-    'sourcename',
-    'current_page_name',
-    'toc',
-    'page_source_suffix',
-]
 
 
 def update_body(app, pagename, templatename, context, doctree):
@@ -194,44 +174,6 @@ def update_body(app, pagename, templatename, context, doctree):
                                                         app.builder.templates)
 
 
-def generate_json_artifacts(app, pagename, templatename, context, doctree):
-    """
-    Generate JSON artifacts for each page.
-
-    This way we can skip generating this in other build step.
-    """
-    if app.builder.name not in JSON_BUILDERS:
-        return
-    try:
-        # We need to get the output directory where the docs are built
-        # _build/json.
-        build_json = os.path.abspath(
-            os.path.join(app.outdir, '..', 'json')
-        )
-        outjson = os.path.join(build_json, pagename + '.fjson')
-        outdir = os.path.dirname(outjson)
-        if not os.path.exists(outdir):
-            os.makedirs(outdir)
-        with open(outjson, 'w+') as json_file:
-            to_context = {
-                key: context.get(key, '')
-                for key in JSON_KEYS
-            }
-            json.dump(to_context, json_file, indent=4)
-    except TypeError:
-        log.exception(
-            'Fail to encode JSON for page {page}'.format(page=outjson)
-        )
-    except IOError:
-        log.exception(
-            'Fail to save JSON output for page {page}'.format(page=outjson)
-        )
-    except Exception:
-        log.exception(
-            'Failure in JSON search dump for page {page}'.format(page=outjson)
-        )
-
-
 def remove_search_init(app, exception):
     """
     Remove Sphinx's Search.init() so it can be initialized by Read the Docs.
@@ -350,7 +292,6 @@ class ReadtheDocsSingleFileHTMLBuilderLocalMedia(SingleFileHTMLBuilder):
 def setup(app):
     app.add_builder(ReadtheDocsSingleFileHTMLBuilderLocalMedia)
     app.connect('html-page-context', update_body)
-    app.connect('html-page-context', generate_json_artifacts)
     app.connect('build-finished', remove_search_init)
 
     if sphinx.version_info >= (1, 8, 0):


### PR DESCRIPTION
We were using these for search, but we no longer need them. We index the HTML directly now.

Ref https://github.com/readthedocs/readthedocs.org/issues/10272