### PR TITLE
Reduce log level from warning to info

### DIFF
--- a/readthedocs_ext/readthedocs.py
+++ b/readthedocs_ext/readthedocs.py
@@ -270,7 +270,7 @@ def remove_search_init(app, exception):
             data = replacement_regex.sub(replacement_text, data)
             outfile.write(data)
     else:
-        log.warning('Missing searchtools: {}'.format(searchtools_file))
+        log.info('Missing searchtools: {}'.format(searchtools_file))
 
 
 def dump_telemetry(app, config):


### PR DESCRIPTION
Projects using `fail_on_warning` fails because we are logging this warning here.

Closes #128