### PR TITLE
Keep default `Search.init` behavior if addons injected

### DIFF
--- a/readthedocs_ext/readthedocs.py
+++ b/readthedocs_ext/readthedocs.py
@@ -254,12 +254,16 @@ def remove_search_init(app, exception):
 /* Search initialization manipulated by Read the Docs */
 /* See https://github.com/readthedocs/addons/issues/213 for more information */
 
-const addonsInjected = document.querySelector(
-        'script[src="/_/static/javascript/readthedocs-addons.js"]'
-        );
-if (addonsInjected) {
-  _ready(Search.init);
+function triggerSearch() {
+  const addonsInjected = document.querySelector(
+          'script[src="/_/static/javascript/readthedocs-addons.js"]'
+          );
+  if (addonsInjected) {
+    Search.init();
+  }
 }
+
+_ready(triggerSearch);
 """
         replacement_regex = re.compile(
             r'''

--- a/readthedocs_ext/readthedocs.py
+++ b/readthedocs_ext/readthedocs.py
@@ -254,7 +254,9 @@ def remove_search_init(app, exception):
 /* Search initialization manipulated by Read the Docs */
 /* See https://github.com/readthedocs/addons/issues/213 for more information */
 
-const addonsInjected = document.querySelector('script[src="/_/static/javascript/readthedocs-addons.js"]');
+const addonsInjected = document.querySelector(
+        'script[src="/_/static/javascript/readthedocs-addons.js"]'
+        );
 if (addonsInjected) {
   _ready(Sphinx.init);
 }

--- a/readthedocs_ext/readthedocs.py
+++ b/readthedocs_ext/readthedocs.py
@@ -250,7 +250,15 @@ def remove_search_init(app, exception):
     )
 
     if os.path.exists(searchtools_file):
-        replacement_text = '/* Search initialization removed for Read the Docs */'
+        replacement_text = """
+/* Search initialization manipulated by Read the Docs */
+/* See https://github.com/readthedocs/addons/issues/213 for more information */
+
+const addonsInjected = document.querySelector('script[src="/_/static/javascript/readthedocs-addons.js"]');
+if (addonsInjected) {
+  _ready(Sphinx.init);
+}
+"""
         replacement_regex = re.compile(
             r'''
             ^(\$\(document\).ready\(function\s*\(\)\s*{(?:\n|\r\n?)

--- a/readthedocs_ext/readthedocs.py
+++ b/readthedocs_ext/readthedocs.py
@@ -250,7 +250,7 @@ def remove_search_init(app, exception):
     )
 
     if os.path.exists(searchtools_file):
-        replacement_text = """
+        replacement_text = r"""
 /* Search initialization manipulated by Read the Docs */
 /* See https://github.com/readthedocs/addons/issues/213 for more information */
 
@@ -258,7 +258,7 @@ const addonsInjected = document.querySelector(
         'script[src="/_/static/javascript/readthedocs-addons.js"]'
         );
 if (addonsInjected) {
-  _ready(Sphinx.init);
+  _ready(Search.init);
 }
 """
         replacement_regex = re.compile(

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -63,7 +63,9 @@ class IntegrationTests(LanguageIntegrationTests):
 /* Search initialization manipulated by Read the Docs */
 /* See https://github.com/readthedocs/addons/issues/213 for more information */
 
-const addonsInjected = document.querySelector('script[src="/_/static/javascript/readthedocs-addons.js"]');
+const addonsInjected = document.querySelector(
+        'script[src="/_/static/javascript/readthedocs-addons.js"]'
+        );
 if (addonsInjected) {
   _ready(Sphinx.init);
 }

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -59,8 +59,16 @@ class IntegrationTests(LanguageIntegrationTests):
     def test_searchtools_is_patched(self):
         with build_output('pyexample', '_build/html/_static/searchtools.js',
                           builder='html') as data:
-            self.assertNotIn('Search.init();', data)
-            self.assertIn('Search initialization removed for Read the Docs', data)
+            search_content = """
+/* Search initialization manipulated by Read the Docs */
+/* See https://github.com/readthedocs/addons/issues/213 for more information */
+
+const addonsInjected = document.querySelector('script[src="/_/static/javascript/readthedocs-addons.js"]');
+if (addonsInjected) {
+  _ready(Sphinx.init);
+}
+"""
+            self.assertIn(search_content, data)
 
     def test_generate_json_artifacts(self):
         self._run_test(

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -61,7 +61,9 @@ class IntegrationTests(LanguageIntegrationTests):
                           builder='html') as data:
             search_content = "if (addonsInjected)"
             self.assertIn(search_content, data)
-            search_content = "_ready(Search.init);"
+            search_content = "Search.init();"
+            self.assertIn(search_content, data)
+            search_content = "_ready(triggerSearch);"
             self.assertIn(search_content, data)
 
     def test_generate_json_artifacts(self):

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -59,17 +59,9 @@ class IntegrationTests(LanguageIntegrationTests):
     def test_searchtools_is_patched(self):
         with build_output('pyexample', '_build/html/_static/searchtools.js',
                           builder='html') as data:
-            search_content = """
-/* Search initialization manipulated by Read the Docs */
-/* See https://github.com/readthedocs/addons/issues/213 for more information */
-
-const addonsInjected = document.querySelector(
-        'script[src="/_/static/javascript/readthedocs-addons.js"]'
-        );
-if (addonsInjected) {
-  _ready(Sphinx.init);
-}
-"""
+            search_content = "if (addonsInjected)"
+            self.assertIn(search_content, data)
+            search_content = "_ready(Search.init);"
             self.assertIn(search_content, data)
 
     def test_generate_json_artifacts(self):


### PR DESCRIPTION
The extension removes the call to `Search.init` because it needs to perform some injection before calling this method. The old implementation of the `readthedocs-doc-embed.js` calls this method manually after modifying some stuff.

However, with the introduction of addons, we don't want to manipulate the defaults and the Sphinx default search should work out-of-the-box.

To keep the default behavior when addons is enabled, we check for addons javascript and if it's present we call `_ready(Search.init);` as the default Sphinx code does.

See https://github.com/readthedocs/addons/issues/213 for more information.

Closes https://github.com/readthedocs/addons/issues/213