### PR TITLE
Revert "Keep default `Search.init` behavior if addons injected (#131)"

### DIFF
--- a/readthedocs_ext/readthedocs.py
+++ b/readthedocs_ext/readthedocs.py
@@ -250,21 +250,7 @@ def remove_search_init(app, exception):
     )
 
     if os.path.exists(searchtools_file):
-        replacement_text = r"""
-/* Search initialization manipulated by Read the Docs */
-/* See https://github.com/readthedocs/addons/issues/213 for more information */
-
-function triggerSearch() {
-  const addonsInjected = document.querySelector(
-          'script[src="/_/static/javascript/readthedocs-addons.js"]'
-          );
-  if (addonsInjected) {
-    Search.init();
-  }
-}
-
-_ready(triggerSearch);
-"""
+        replacement_text = '/* Search initialization removed for Read the Docs */'
         replacement_regex = re.compile(
             r'''
             ^(\$\(document\).ready\(function\s*\(\)\s*{(?:\n|\r\n?)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -59,12 +59,8 @@ class IntegrationTests(LanguageIntegrationTests):
     def test_searchtools_is_patched(self):
         with build_output('pyexample', '_build/html/_static/searchtools.js',
                           builder='html') as data:
-            search_content = "if (addonsInjected)"
-            self.assertIn(search_content, data)
-            search_content = "Search.init();"
-            self.assertIn(search_content, data)
-            search_content = "_ready(triggerSearch);"
-            self.assertIn(search_content, data)
+            self.assertNotIn('Search.init();', data)
+            self.assertIn('Search initialization removed for Read the Docs', data)
 
     def test_generate_json_artifacts(self):
         self._run_test(


### PR DESCRIPTION
This reverts commit 66e11678d4d0b517aa49c3345e4f15b56ea221ce.

This was implemented at Cloudflare level using a worker. See https://github.com/readthedocs/readthedocs-ops/pull/1430